### PR TITLE
Allow players to choose marker, stop using atoms

### DIFF
--- a/src/clojure_tictactoe/cli/input/input_getter.clj
+++ b/src/clojure_tictactoe/cli/input/input_getter.clj
@@ -1,6 +1,7 @@
 (ns clojure-tictactoe.cli.input.input-getter
   (:require [clojure.string :as string]
-            [clojure-tictactoe.game.board :as board]))
+            [clojure-tictactoe.game.board :as board]
+            [clojure-tictactoe.cli.output.instructions-printer :as instructions-printer]))
 
 (defn get-user-input []
   (let [user-input (string/trim (read-line))]
@@ -20,6 +21,11 @@
                           (< formatted-input 9))]
       (when valid-numeral
         formatted-input))))
+
+(defn get-player-marker [player]
+  (instructions-printer/print-marker-instructions player)
+  (get-user-input)
+  )
 
 (defn get-player-choice []
   (println (str "Which space would you like to mark?"))

--- a/src/clojure_tictactoe/cli/input/input_getter.clj
+++ b/src/clojure_tictactoe/cli/input/input_getter.clj
@@ -15,12 +15,12 @@
   nil)
 
 (defn parse-move-input [input]
-  (let [formatted-input (read-string input)]
-    (let [valid-numeral (and
+  (let [formatted-input (read-string input)
+        valid-numeral (and
                           (number? formatted-input)
                           (< formatted-input 9))]
       (when valid-numeral
-        formatted-input))))
+        formatted-input)))
 
 (defn get-player-marker [player]
   (instructions-printer/print-marker-instructions player)

--- a/src/clojure_tictactoe/cli/output/instructions_printer.clj
+++ b/src/clojure_tictactoe/cli/output/instructions_printer.clj
@@ -20,3 +20,8 @@ Examples:
 (defn print-game-intro []
   (println welcome-message)
   (println instructions-message))
+
+
+
+(defn print-marker-instructions [player]
+  (println (str "What marker would you like for " player "?")))

--- a/src/clojure_tictactoe/game/game_play.clj
+++ b/src/clojure_tictactoe/game/game_play.clj
@@ -8,12 +8,18 @@
             [clojure-tictactoe.game.game-rules :as rules]
             ))
 
+(def standard-board-size 9)
+
 (defn player-move [move-function board marker]
   (board/mark-space (move-function board) marker board))
 
 (defn continue-game [board markers turn]
-  (let [new-board (player-move (players/choose-player-function turn) board (markers (players/current-player turn)))]
-
+  (let [new-board (player-move
+                    (players/choose-player-function
+                      turn)
+                    board
+                    (markers
+                      (players/current-player turn)))]
     (board-printer/print-board new-board)
     new-board))
 
@@ -29,7 +35,7 @@
 (defn initialize-game []
   (instructions-printer/print-game-intro)
   (input-getter/continue-to-game)
-  (let [board (board/render-empty-board 9)
+  (let [board (board/render-empty-board standard-board-size)
         markers (players/acquire-both-markers '("you" "the computer"))]
     (board-printer/print-board board)
     (game-loop board markers 0)))

--- a/src/clojure_tictactoe/game/game_play.clj
+++ b/src/clojure_tictactoe/game/game_play.clj
@@ -8,27 +8,28 @@
             [clojure-tictactoe.game.game-rules :as rules]
             ))
 
-(defn player-move [move-function board]
-  (board/mark-space (move-function board) @players/player-atom board))
+(defn player-move [move-function board marker]
+  (board/mark-space (move-function board) marker board))
 
-(defn continue-game [board]
-  (let [new-board (player-move (players/choose-player-function @players/player-atom) board)]
+(defn continue-game [board markers turn]
+  (let [new-board (player-move (players/choose-player-function turn) board (markers (players/current-player turn)))]
+
     (board-printer/print-board new-board)
-    (players/player-swap)
     new-board))
 
-(defn game-loop [board]
-  (loop [board board]
-    (if-not (rules/game-over? board)
-      (let [new-board (continue-game board)]
-        (recur new-board))
-      (if-let [results (rules/assess-winner board)]
-        (println (end-printer/game-won-message results))
-        (println end-printer/game-tie-message)))))
+(defn game-loop [board markers turn]
+  (if-not (rules/game-over? board)
+    (let [new-board (continue-game board markers turn)]
+
+      (recur new-board markers (+ 1 turn)))
+    (if-let [results (rules/assess-winner board)]
+      (println (end-printer/game-won-message results))
+      (println end-printer/game-tie-message))))
 
 (defn initialize-game []
   (instructions-printer/print-game-intro)
   (input-getter/continue-to-game)
-  (let [board (board/render-empty-board 9)]
+  (let [board (board/render-empty-board 9)
+        markers (players/acquire-both-markers '("you" "the computer"))]
     (board-printer/print-board board)
-    (game-loop board)))
+    (game-loop board markers 0)))

--- a/src/clojure_tictactoe/game/game_rules.clj
+++ b/src/clojure_tictactoe/game/game_rules.clj
@@ -8,10 +8,10 @@
   (apply map list (horizontal-win-options board)))
 
 (defn diagonal-win-options [board]
-  (let [side-length (board/side-length board)]
-    (let [top-left-to-bottom-right-diagonal (take side-length (range 0 (count board) (+ 1 side-length)))
-          bottom-left-to-top-right-diagonal (take side-length (range (- side-length 1) (count board) (- side-length 1)))]
-      (list top-left-to-bottom-right-diagonal bottom-left-to-top-right-diagonal))))
+  (let [side-length (board/side-length board)
+        top-left-to-bottom-right-diagonal (take side-length (range 0 (count board) (+ 1 side-length)))
+        bottom-left-to-top-right-diagonal (take side-length (range (- side-length 1) (count board) (- side-length 1)))]
+      (list top-left-to-bottom-right-diagonal bottom-left-to-top-right-diagonal)))
 
 (defn all-win-options [board]
   (concat (diagonal-win-options board) (vertical-win-options board) (horizontal-win-options board)))

--- a/src/clojure_tictactoe/game/players.clj
+++ b/src/clojure_tictactoe/game/players.clj
@@ -26,8 +26,8 @@
 
 (defn current-player [turn]
   (if (even? turn)
-    0
-    1))
+    (let [first-player 0])
+    (let [second-player 1])))
 
 (defn choose-player-function [turn]
   (if (= 0 (current-player turn))

--- a/src/clojure_tictactoe/game/players.clj
+++ b/src/clojure_tictactoe/game/players.clj
@@ -2,20 +2,34 @@
   (:require [clojure-tictactoe.game.computer-opponent :as ai]
             [clojure-tictactoe.cli.input.input-getter :as input-getter]))
 
-(def player-atom (atom "x"))
+(defn acceptable-marker-option? [potential-marker]
+  (-> potential-marker
+    (count)
+    (= 1)))
 
-(defn switch-player [current-player]
-  (if (= current-player "x")
-    "o"
-    "x"))
+(defn distinct-markers? [markers]
+  (->> markers
+    (apply =)
+    (not)))
 
-(defn player-swap []
-  (swap! player-atom switch-player))
+(defn acquire-one-marker [player]
+  (let [marker (input-getter/get-player-marker player)]
+    (if (acceptable-marker-option? marker)
+      marker
+      (recur player))))
 
-(defn human-player-move [board]
-  (input-getter/get-player-move board))
+(defn acquire-both-markers [players]
+  (let [markers (map acquire-one-marker players)]
+    (if (distinct-markers? markers)
+      (into [] markers)
+      (recur players))))
 
-(defn choose-player-function [player]
-  (if (= player "x")
-    human-player-move
+(defn current-player [turn]
+  (if (even? turn)
+    0
+    1))
+
+(defn choose-player-function [turn]
+  (if (= 0 (current-player turn))
+    input-getter/get-player-move
     ai/make-move))

--- a/test/clojure_tictactoe/cli/input/input_getter_test.clj
+++ b/test/clojure_tictactoe/cli/input/input_getter_test.clj
@@ -14,6 +14,7 @@
       (testing "The function returns nil once newline has been entered"
         (is (nil? (with-in-str "\n" (continue-to-game))))))))
 
+
 (testing "Player moves"
   (testing "get-player-choice"
     (deftest get-player-choice-test
@@ -23,6 +24,11 @@
     (deftest get-player-choice-test-bad-arguments
       (testing "Doesn't accept non-numeric input"
         (is (= (with-in-str (helper/make-input ["Alphabet" "8"]) (get-player-choice)) 8 )))))
+
+  (testing "get-player-move"
+    (deftest get-player-move-test
+      (testing "Doesn't accept taken input, does accept open space"
+        (is (= (with-in-str (helper/make-input ["0" "8"]) (get-player-move ["x" 1 2 3 4 5 6 7 8])) 8 )))))
 
   (testing "parse-move-input"
     (deftest parse-move-input-test-with-number-input

--- a/test/clojure_tictactoe/cli/output/instructions_printer_test.clj
+++ b/test/clojure_tictactoe/cli/output/instructions_printer_test.clj
@@ -10,3 +10,10 @@
       (testing "Intro messages"
        (is (string/includes? (with-out-str (print-game-intro)) welcome-message))
        (is (string/includes? (with-out-str (print-game-intro)) instructions-message))))))
+
+(testing "Markers"
+  (testing "print-marker-instructions"
+    (deftest print-marker-instructions-test
+      (testing "displays passed param"
+        (is (string/includes? (with-out-str (print-marker-instructions "test")) "test?")))))
+  )

--- a/test/clojure_tictactoe/game/game_play_test.clj
+++ b/test/clojure_tictactoe/game/game_play_test.clj
@@ -8,4 +8,4 @@
 
 (deftest player-move-test-good-argument
   (testing "Accepts good player move"
-    (is (= (player-move (fn [& args] 8) [0 1 2 3 4 5 6 7 8]) [0 1 2 3 4 5 6 7 "x"]))))
+    (is (= (player-move (fn [& args] 8) [0 1 2 3 4 5 6 7 8] "x") [0 1 2 3 4 5 6 7 "x"]))))

--- a/test/clojure_tictactoe/game/players_test.clj
+++ b/test/clojure_tictactoe/game/players_test.clj
@@ -3,29 +3,62 @@
             [clojure.string :as string]
             [clojure-tictactoe.helpers :as helper]
             [clojure-tictactoe.game.players :refer :all]
-            [clojure-tictactoe.game.computer-opponent :as ai]))
+            [clojure-tictactoe.game.computer-opponent :as ai]
+            [clojure-tictactoe.cli.input.input-getter :as input-getter]))
 
 (testing "Players"
-  (testing "switch-players"
-    (deftest switch-player-test-when-x
-      (testing "Returns o when x is passed in"
-        (is (= "o" (switch-player "x")))))
+  (testing "current-player"
+    (deftest current-player-test-first-player
+      (testing "Returns 0 when it's the first player's turn"
+        (is (= 0 (current-player 0)))
+        (is (= 0 (current-player 2)))
+        (is (= 0 (current-player 8)))))
 
-    (deftest switch-player-test-when-o
-      (testing "Returns x when o is passed in"
-        (is (= "x" (switch-player "o"))))))
-
-  (testing "human-player-move"
-    (deftest human-player-move-test
-      (testing "Doesn't accept taken input, does accept open space"
-        (is (= (with-in-str (helper/make-input ["0" "8"]) (human-player-move ["x" 1 2 3 4 5 6 7 8])) 8 )))))
+    (deftest current-player-test-second-player
+      (testing "Returns 1 when it's the second player's turn"
+        (is (= 1 (current-player 1)))
+        (is (= 1 (current-player 3)))
+        (is (= 1 (current-player 7))))))
 
   (testing "player move logic"
-    (deftest choose-player-function-test-x
-      (testing "Returns the human-move function for player x"
-        (is (= human-player-move (choose-player-function "x")))))
+    (deftest choose-player-function-test-player-one
+      (testing "Returns the human-move function for player one"
+        (is (= input-getter/get-player-move (choose-player-function 0)))))
 
-    (deftest choose-player-function-test-x
-      (testing "Returns the human-move function for player o"
-        (is (= ai/make-move (choose-player-function "o")))))))
+    (deftest choose-player-function-test-player-two
+      (testing "Returns the ai-move function for player two"
+        (is (= ai/make-move (choose-player-function 1)))))))
 
+(testing "Player Markers"
+
+  (testing "acceptable-marker-option?"
+
+    (deftest acceptable-marker-option?-test-too-long
+      (testing "returns false if the potential marker is longer than one char"
+        (is (false? (acceptable-marker-option? "Nope")))))
+
+    (deftest acceptable-marker-option?-test-good
+      (testing "returns true for markers that are only one char long"
+        (is (true? (acceptable-marker-option? "x"))))))
+
+  (testing "distinct-markers?"
+
+    (deftest distinct-markers?-test-redundant-markers
+      (testing "Returns false if both markers are the same"
+        (is (false? (distinct-markers? '("x" "x"))))))
+
+    (deftest distinct-markers?-test-distinct-markers
+      (testing "Returns true if markers are distinct"
+        (is (true? (distinct-markers? '("o" "x")))))))
+
+  (testing "acquire-one-marker"
+
+    (deftest acquire-one-marker-test
+      (testing "Only accepts string that is one char"
+        (is (= "x" (with-in-str (helper/make-input ["too long" " " "x"]) (acquire-one-marker "Player 1")))))))
+
+  (testing "acquire-both-markers"
+
+    (deftest acquire-both-markers-test
+      (testing "Only accepts distinct markers"
+        (is (= '("x" "o") (with-in-str (helper/make-input ["x" "x" "x" "o"]) (acquire-both-markers '("Player 1" "Player 2")))))))))


### PR DESCRIPTION
Players can now choose their markers and the marker of the computer opponent. The marker must be one character in length and cannot be the same as the other marker.

Player status is now being determined by a "turn" instead of clojure's atom data structure for a more functional approach.